### PR TITLE
Fixes bug with mets.xml

### DIFF
--- a/app/models/epdcx.rb
+++ b/app/models/epdcx.rb
@@ -1,6 +1,7 @@
 class Epdcx
-  def initialize(xml, submission)
+  def initialize(xml, submission, callback_uri)
     @xml = xml
+    @callback_uri = callback_uri
     @xml['epdcx'].descriptionSet(
       'xmlns:epdcx' => 'http://purl.org/eprint/epdcx/2006-11-16/') do
       work(submission)
@@ -27,6 +28,7 @@ class Epdcx
 
   def work(submission)
     @xml['epdcx'].description('epdcx:resourceId' => 'sword-mets-epdcx-1') do
+      statement('http://libraries.mit.edu/xmlns/callback', @callback_uri)
       scholarly_work
       statement('http://purl.org/dc/elements/1.1/title', submission.title)
       statement('http://purl.org/dc/elements/1.1/creator', submission.author)

--- a/app/models/mets.rb
+++ b/app/models/mets.rb
@@ -17,7 +17,6 @@ class Mets
         'xmlns:mets' => 'http://www.loc.gov/METS/',
         'xmlns:xlink' => 'http://www.w3.org/1999/xlink',
         'xmlns:epdcx' => 'http://purl.org/eprint/epdcx/2006-11-16/',
-        'xmlns:callback' => '',
         'PROFILE' => 'DSpace METS SIP Profile 1.0') do
         overall_structure(xml)
       end
@@ -27,7 +26,6 @@ class Mets
   def overall_structure(xml)
     header(xml)
     dmd(xml)
-    amd(xml)
     filesec(xml)
     structmap(xml)
   end
@@ -37,18 +35,6 @@ class Mets
       xml['mets'].agent('ROLE' => 'DISSEMINATOR',
                         'TYPE' => 'ORGANIZATION') do
         xml['mets'].name('MIT Libraries: QuickSubmit')
-      end
-    end
-  end
-
-  def amd(xml)
-    xml['mets'].amdSec('ID' => 'mitqs_amd') do
-      xml['mets'].techMD('ID' => 'mitqs_amd_tech') do
-        xml['mets'].mdWrap('MDTYPE' => 'OTHER', 'MIMETYPE' => 'text/xml') do
-          xml['mets'].xmlData do
-            xml['callback'].callback_uri(@callback_uri)
-          end
-        end
       end
     end
   end
@@ -94,7 +80,7 @@ class Mets
 
   def xml_data(xml)
     xml['mets'].xmlData do
-      Epdcx.new(xml, @submission)
+      Epdcx.new(xml, @submission, @callback_uri)
     end
   end
 end

--- a/test/models/epdcx_test.rb
+++ b/test/models/epdcx_test.rb
@@ -6,7 +6,7 @@ class EpdcxTest < ActiveSupport::TestCase
       sub = submissions(:sub_two)
       builder = Nokogiri::XML::Builder.new { |xml| xml }
       xsd = Nokogiri::XML::Schema(File.read('epdcx.xsd'))
-      xml = Epdcx.new(builder, sub).to_xml
+      xml = Epdcx.new(builder, sub, 'http://example.com').to_xml
       doc = Nokogiri::XML(xml)
       assert_equal(true, xsd.valid?(doc))
     end
@@ -17,7 +17,7 @@ class EpdcxTest < ActiveSupport::TestCase
       sub = submissions(:sub_one)
       builder = Nokogiri::XML::Builder.new { |xml| xml }
       xsd = Nokogiri::XML::Schema(File.read('epdcx.xsd'))
-      xml = Epdcx.new(builder, sub).to_xml
+      xml = Epdcx.new(builder, sub, 'http://example.com').to_xml
       doc = Nokogiri::XML(xml)
       assert_equal(true, xsd.valid?(doc))
     end


### PR DESCRIPTION
c96f8fc introduced a bug in which
dspace was unable to parse the xml using a namespace with no
definition. Falling back to the probably saner default namespace here
should solve the problem.
