### PR TITLE
Write zip file to disk then include it in sword post

### DIFF
--- a/app/controllers/callbacks_controller.rb
+++ b/app/controllers/callbacks_controller.rb
@@ -5,7 +5,7 @@ class CallbacksController < ApplicationController
     initial_status = @submission.status
     extract_and_update_status_and_handle(params)
     unless @submission.save
-      fail ActionController::RoutingError, 'Approved Status Requires Handle'
+      raise ActionController::RoutingError, 'Approved Status Requires Handle'
     end
     @submission.send_status_email unless @submission.status == initial_status
     render nothing: true, status: 200
@@ -15,14 +15,14 @@ class CallbacksController < ApplicationController
 
   def extract_and_update_status_and_handle(params)
     json = JSON.parse(params[:body])
-    fail ActionController::RoutingError, 'Invalid Status' unless json['status']
+    raise ActionController::RoutingError, 'Invalid Status' unless json['status']
     @submission.status = json['status'] if valid_status?(json['status'])
     extract_and_update_handle(json) if @submission.status == 'approved'
   end
 
   def validate_submission_and_params(params)
-    fail ActionController::RoutingError, 'Not Found' unless @submission
-    fail ActionController::RoutingError, 'Invalid Status' unless params[:body]
+    raise ActionController::RoutingError, 'Not Found' unless @submission
+    raise ActionController::RoutingError, 'Invalid Status' unless params[:body]
   end
 
   def extract_and_update_handle(json)

--- a/app/models/sword.rb
+++ b/app/models/sword.rb
@@ -11,8 +11,9 @@ class Sword
   end
 
   def deposit
+    @submission.to_sword_package(@callback_uri)
     @response = @sword_server.post(
-      @submission.to_sword_package(@callback_uri),
+      File.read(@submission.sword_path),
       content_type: 'application/zip',
       x_packaging: 'http://purl.org/net/sword-types/METSDSpaceSIP')
   end


### PR DESCRIPTION
closes #45

Ideally we’d not write this to disk and instead just generate it on
demand and stream it through. It’s likely possible but this was a quick
fix and should work fine as it’ll never be run on separate dynos since
it’s all once request.
