### PR TITLE
Allow all emails to be disabled

### DIFF
--- a/app/mailers/submission_mailer.rb
+++ b/app/mailers/submission_mailer.rb
@@ -1,20 +1,24 @@
 class SubmissionMailer < ApplicationMailer
   def queued(submission)
+    return if ENV['DISABLE_ALL_EMAIL']
     @submission = submission
     mail(to: @submission.user.email, subject: 'Submission Received')
   end
 
   def deposited(submission)
+    return if ENV['DISABLE_ALL_EMAIL']
     @submission = submission
     mail(to: @submission.user.email, subject: 'Submission Complete')
   end
 
   def rejected(submission)
+    return if ENV['DISABLE_ALL_EMAIL']
     @submission = submission
     mail(to: @submission.user.email, subject: 'Submission Problem')
   end
 
   def failed(submission, error)
+    return if ENV['DISABLE_ALL_EMAIL']
     @submission = submission
     @error = error
     mail(to: User.where(admin: true).map(&:email),


### PR DESCRIPTION
Until sending emails from Heroku is resolved, we need a mechanism to
disable all emails. This might never be merged… we’ll see how long
solving this takes.
