### PR TITLE
Removes csrf check from callback status post

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,3 +14,6 @@ AllCops:
 ClassLength:
   Exclude:
     - test/**/*
+
+Style/FrozenStringLiteralComment:
+  Enabled: false

--- a/app/controllers/callbacks_controller.rb
+++ b/app/controllers/callbacks_controller.rb
@@ -1,4 +1,6 @@
 class CallbacksController < ApplicationController
+  skip_before_action :verify_authenticity_token, only: :status
+
   def status
     @submission = Submission.find_by_uuid(params[:uuid])
     validate_submission_and_params(params)
@@ -14,20 +16,18 @@ class CallbacksController < ApplicationController
   private
 
   def extract_and_update_status_and_handle(params)
-    json = JSON.parse(params[:body])
-    raise ActionController::RoutingError, 'Invalid Status' unless json['status']
-    @submission.status = json['status'] if valid_status?(json['status'])
-    extract_and_update_handle(json) if @submission.status == 'approved'
+    unless params[:status]
+      raise ActionController::RoutingError, 'Invalid Status'
+    end
+    @submission.status = params[:status] if valid_status?(params[:status])
+    @submission.handle = params[:handle] if @submission.status == 'approved'
   end
 
   def validate_submission_and_params(params)
     raise ActionController::RoutingError, 'Not Found' unless @submission
-    raise ActionController::RoutingError, 'Invalid Status' unless params[:body]
-  end
-
-  def extract_and_update_handle(json)
-    handle = json['handle']
-    @submission.handle = handle
+    unless params[:status]
+      raise ActionController::RoutingError, 'Invalid Status'
+    end
   end
 
   # move this to the model?

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -82,7 +82,7 @@ class SubmissionsController < ApplicationController
   end
 
   def callback_uri
-    "#{root_url}/callbacks/status/#{@submission.uuid}"
+    "#{root_url}callbacks/status/#{@submission.uuid}"
   end
 
   def submission_params

--- a/app/views/submissions/index.html.erb
+++ b/app/views/submissions/index.html.erb
@@ -4,14 +4,14 @@ View:
  <%= link_to('All', submissions_path, class: 'btn btn-default') %>
  <%= link_to('Failed', submissions_path(filter: 'failed'), class: 'btn btn-default') %>
  <%= link_to('In Review Queue', submissions_path(filter: 'in review queue'), class: 'btn btn-default') %>
- <%= link_to('Deposited', submissions_path(filter: 'deposited'), class: 'btn btn-default') %>
+ <%= link_to('Approved', submissions_path(filter: 'approved'), class: 'btn btn-default') %>
 
 <hr />
 
 <% if @submissions %>
 
   <% @submissions.each do |sub| %>
-    <% if sub.status == 'deposited' %>
+    <% if sub.status == 'approved' %>
       <div class="panel panel-success">
     <% elsif sub.status == 'in review queue' %>
       <div class="panel panel-info">

--- a/test/features/submission_index_pages_test.rb
+++ b/test/features/submission_index_pages_test.rb
@@ -53,7 +53,7 @@ class SubmissionIndexPagesTest < Capybara::Rails::TestCase
     visit submissions_path
     assert_text('popcorn soup')
 
-    click_link('Deposited')
+    click_link('Approved')
     assert_text('popcorn soup')
 
     click_link('Failed')

--- a/test/fixtures/submissions.yml
+++ b/test/fixtures/submissions.yml
@@ -45,4 +45,4 @@ sub_deposited:
     funders: '["Department of Energy (DOE)"]'
     user: one
     uuid: 7648b505-af79-4a2b-abcb-2727f716100c
-    status: 'deposited'
+    status: 'approved'


### PR DESCRIPTION
This protection is inappropriate for this scenario as this is
essentially an API call and not an in-app submission.

Also tweaks callback uri and fixes assumptions about incoming json.
