### PR TITLE
Don't include ui only funders in mets

### DIFF
--- a/app/models/epdcx.rb
+++ b/app/models/epdcx.rb
@@ -59,8 +59,8 @@ class Epdcx
   end
 
   def funders(submission)
-    return unless submission.funders.present?
-    submission.funders.each do |funder|
+    return unless submission.funders_minus_ui_only_funders.present?
+    submission.funders_minus_ui_only_funders.each do |funder|
       statement('http://libraries.mit.edu/xmlns/sponsor', funder)
     end
   end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -88,7 +88,15 @@ class Submission < ActiveRecord::Base
     end
   end
 
+  def funders_minus_ui_only_funders
+    funders - ui_only_funders
+  end
+
   def valid_funders
+    submittable_funders + ui_only_funders
+  end
+
+  def submittable_funders
     ['Department of Defense (DoD)',
      'Department of Energy (DOE)',
      'Department of Transportation (DOT)',
@@ -97,7 +105,10 @@ class Submission < ActiveRecord::Base
      'National Center for Atmospheric Research (NCAR)',
      'National Ocean and Atmospheric Administration (NOAA)',
      'National Science Foundation (NSF)',
-     'United States Department of Agriculture (USDA)',
-     'None / Other']
+     'United States Department of Agriculture (USDA)']
+  end
+
+  def ui_only_funders
+    ['None / Other']
   end
 end

--- a/test/models/submission_test.rb
+++ b/test/models/submission_test.rb
@@ -68,6 +68,20 @@ class SubmissionTest < ActiveSupport::TestCase
     assert_not sub.valid?
   end
 
+  test 'valid with a ui only funder' do
+    sub = submissions(:sub_one)
+    sub.funders = ['None / Other']
+    assert sub.valid?
+  end
+
+  test 'funders_minus_ui_only_funders' do
+    sub = submissions(:sub_one)
+    sub.funders << 'None / Other'
+    assert_equal(sub.funders.include?('None / Other'), true)
+    assert_equal(sub.funders_minus_ui_only_funders.include?('None / Other'),
+                 false)
+  end
+
   test 'valid with uri handle' do
     sub = submissions(:sub_one)
     sub.handle = 'http://example.com/123456/789.0'


### PR DESCRIPTION
The ui wants to display and treat as valid funders like “none / other”
but we don’t want that stuff to actually make it into dspace so we
should not include them in the generated mets.
closes #68
