### PR TITLE
Bug fixed upstream so we no longer need our fork

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,9 @@ ruby '2.3.1'
 
 gem 'rails', '5.0.0'
 gem 'aws-sdk', '~> 2'
-gem 'bootstrap_form', git: 'https://github.com/MITLibraries/rails-bootstrap-forms',
-                      branch: 'use_parameterize_for_check_box_label_for'
+gem 'bootstrap_form',
+    git: 'https://github.com/bootstrap-ruby/rails-bootstrap-forms.git',
+    ref: 'de93b85'
 gem 'cancancan'
 gem 'delayed_job_active_record'
 gem 'devise'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
-  remote: https://github.com/MITLibraries/rails-bootstrap-forms
-  revision: bae763aceddf818822875871b5059214fb7eab98
-  branch: use_parameterize_for_check_box_label_for
+  remote: https://github.com/bootstrap-ruby/rails-bootstrap-forms.git
+  revision: de93b855371937b05ab1f83339544c82da7738bb
+  ref: de93b85
   specs:
     bootstrap_form (2.4.0)
 


### PR DESCRIPTION
One they push a new release, we can switch to the release instead of pulling from the repo.
