### PR TITLE
adjust footer logo sizing

### DIFF
--- a/app/assets/stylesheets/layout.css.erb
+++ b/app/assets/stylesheets/layout.css.erb
@@ -560,7 +560,7 @@ hr {
   fill: #f3f3f3;
 }
 .wrap-footer .logo-mit-lib svg {
-  width: 100%;
+  width: auto;
   height: auto;
 }
 .wrap-footer .wrap-usergroups {


### PR DESCRIPTION
There is a bug where some browsers show the footer image too large. 

![pasted image at 2016_10_27 09_27 am](https://cloud.githubusercontent.com/assets/4327102/19769017/b8649f06-9c27-11e6-8f61-1a16bbbdf554.png)

This should fix it. 

Code review: @JPrevost 
