### PR TITLE
add OpenID sign-in info to sidebar

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -83,7 +83,14 @@
         <!-- close content-main -->
 
         <aside class="content-sup">
-
+          <% unless user_signed_in? %>
+          <div class="bit">
+            <h3 class="title">MIT OpenID Sign-in</h3>
+            <p>This application uses the MIT OpenId Connect pilot for sign-in (instead of Touchstone) &mdash; it will ask for approval to sign in with your MIT information and credentials. 
+            <a target="_blank" href="https://oidc.mit.edu/">Learn more</a>
+            </p>
+          </div>        
+          <% end %>
           <div class="bit">
             <h3 class="title">Related</h3>
             <ul>


### PR DESCRIPTION
This PR adds a little contextual information about the sign-in method to the sidebar so users have a little heads up that we are using OpenID. 

Code review: @JPrevost 